### PR TITLE
feat: add deletion by ref

### DIFF
--- a/android/src/main/java/com/swmansion/enriched/textinput/EnrichedTextInputView.kt
+++ b/android/src/main/java/com/swmansion/enriched/textinput/EnrichedTextInputView.kt
@@ -1007,8 +1007,8 @@ class EnrichedTextInputView :
 
   fun deleteAtSelection() {
     runAsATransaction {
-      val start = selectionStart
-      val end = selectionEnd
+      val start = selectionStart.coerceAtLeast(0)
+      val end = selectionEnd.coerceAtLeast(0)
 
       if (start != end) {
         text?.delete(start, end)

--- a/android/src/main/java/com/swmansion/enriched/textinput/EnrichedTextInputView.kt
+++ b/android/src/main/java/com/swmansion/enriched/textinput/EnrichedTextInputView.kt
@@ -1005,6 +1005,19 @@ class EnrichedTextInputView :
     selection?.validateStyles()
   }
 
+  fun deleteAtSelection() {
+    runAsATransaction {
+      val start = selectionStart
+      val end = selectionEnd
+
+      if (start != end) {
+        text?.delete(start, end)
+      } else if (start > 0) {
+        text?.delete(start - 1, start)
+      }
+    }
+  }
+
   fun requestHTML(requestId: Int) {
     val html =
       try {

--- a/android/src/main/java/com/swmansion/enriched/textinput/EnrichedTextInputView.kt
+++ b/android/src/main/java/com/swmansion/enriched/textinput/EnrichedTextInputView.kt
@@ -1006,14 +1006,18 @@ class EnrichedTextInputView :
   }
 
   fun deleteAtSelection() {
-    runAsATransaction {
+    val inputConnection = onCreateInputConnection(EditorInfo())
+
+    if (inputConnection != null) {
       val start = selectionStart.coerceAtLeast(0)
       val end = selectionEnd.coerceAtLeast(0)
 
       if (start != end) {
-        text?.delete(start, end)
-      } else if (start > 0) {
-        text?.delete(start - 1, start)
+        // If we have selection - delete it
+        inputConnection.commitText("", 1)
+      } else {
+        // If we don't have selection - delete previous character
+        inputConnection.deleteSurroundingText(1, 0)
       }
     }
   }

--- a/android/src/main/java/com/swmansion/enriched/textinput/EnrichedTextInputViewManager.kt
+++ b/android/src/main/java/com/swmansion/enriched/textinput/EnrichedTextInputViewManager.kt
@@ -479,6 +479,10 @@ class EnrichedTextInputViewManager :
     view?.setTextAlignment(alignment)
   }
 
+  override fun deleteAtSelection(view: EnrichedTextInputView?) {
+    view?.deleteAtSelection()
+  }
+
   override fun measure(
     context: Context,
     localData: ReadableMap?,

--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -1338,19 +1338,24 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
 }
 
 - (void)deleteAtSelection {
-  UITextRange *selectedRange = textView.selectedTextRange;
+  NSRange range = textView.selectedRange;
 
-  if (selectedRange == nil) {
-    return;
+  // Checking if there is anything to delete
+  if (range.location > 0 || range.length > 0) {
+    // If we have no selection - we want to manually set range
+    // to cover the character before the caret
+    if (range.length == 0) {
+      range.location -= 1;
+      range.length = 1;
+    }
+
+    // This imitates delete button on keyboard press
+    if ([textView.delegate textView:textView
+            shouldChangeTextInRange:range
+                    replacementText:@""]) {
+      [textView deleteBackward];
+    }
   }
-
-  if (selectedRange.empty) {
-    [self.textView deleteBackward];
-  } else {
-    [self.textView replaceRange:selectedRange withText:@""];
-  }
-
-  [self anyTextMayHaveBeenModified];
 }
 
 - (void)setCustomSelection:(NSInteger)visibleStart end:(NSInteger)visibleEnd {

--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -1338,7 +1338,11 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
 }
 
 - (void)deleteAtSelection {
-  UITextRange *selectedRange = self.textView.selectedTextRange;
+  UITextRange *selectedRange = textView.selectedTextRange;
+
+  if (selectedRange == nil) {
+    return;
+  }
 
   if (selectedRange.empty) {
     [self.textView deleteBackward];

--- a/ios/EnrichedTextInputView.mm
+++ b/ios/EnrichedTextInputView.mm
@@ -1296,6 +1296,8 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
     if (!_placeholderLabel.isHidden) {
       [self refreshPlaceholderLabelStyles];
     }
+  } else if ([commandName isEqualToString:@"deleteAtSelection"]) {
+    [self deleteAtSelection];
   }
 }
 
@@ -1332,6 +1334,18 @@ Class<RCTComponentViewProtocol> EnrichedTextInputViewCls(void) {
 
   // set selectedRange and check for changes
   textView.selectedRange = NSRange(textView.textStorage.string.length, 0);
+  [self anyTextMayHaveBeenModified];
+}
+
+- (void)deleteAtSelection {
+  UITextRange *selectedRange = self.textView.selectedTextRange;
+
+  if (selectedRange.empty) {
+    [self.textView deleteBackward];
+  } else {
+    [self.textView replaceRange:selectedRange withText:@""];
+  }
+
   [self anyTextMayHaveBeenModified];
 }
 

--- a/src/native/EnrichedTextInput.tsx
+++ b/src/native/EnrichedTextInput.tsx
@@ -277,6 +277,9 @@ export const EnrichedTextInput = ({
     ) => {
       Commands.setTextAlignment(nullthrows(nativeRef.current), alignment);
     },
+    deleteAtSelection: () => {
+      Commands.deleteAtSelection(nullthrows(nativeRef.current));
+    },
   }));
 
   const handleMentionEvent = (e: NativeSyntheticEvent<OnMentionEvent>) => {

--- a/src/spec/EnrichedTextInputNativeComponent.ts
+++ b/src/spec/EnrichedTextInputNativeComponent.ts
@@ -482,6 +482,7 @@ interface NativeCommands {
     viewRef: React.ElementRef<ComponentType>,
     alignment: string
   ) => void;
+  deleteAtSelection: (viewRef: React.ElementRef<ComponentType>) => void;
 }
 
 export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
@@ -516,6 +517,7 @@ export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
     'addMention',
     'requestHTML',
     'setTextAlignment',
+    'deleteAtSelection',
   ],
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -565,6 +565,10 @@ export interface EnrichedTextInputInstance extends NativeMethods {
     alignment: 'left' | 'center' | 'right' | 'justify' | 'auto'
   ) => void;
 
+  /**
+   * Deletes text at current selection. If there is no selection - deletes one character
+   * backwards.
+   */
   deleteAtSelection: () => void;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -564,6 +564,8 @@ export interface EnrichedTextInputInstance extends NativeMethods {
   setTextAlignment: (
     alignment: 'left' | 'center' | 'right' | 'justify' | 'auto'
   ) => void;
+
+  deleteAtSelection: () => void;
 }
 
 export interface ContextMenuItem {

--- a/src/web/EnrichedTextInput.tsx
+++ b/src/web/EnrichedTextInput.tsx
@@ -376,6 +376,17 @@ export const EnrichedTextInput = ({
           runFocused(editor, (c) => c.setTextAlign(alignment));
         }
       },
+      deleteAtSelection: () => {
+        runFocused(editor, (c) => {
+          const { from, to } = editor.state.selection;
+
+          if (from !== to) {
+            return c.deleteSelection();
+          } else {
+            return c.deleteRange({ from: from - 1, to });
+          }
+        });
+      },
     }),
     [editor, mentionIndicatorsRef, useHtmlNormalizerRef]
   );

--- a/src/web/EnrichedTextInput.tsx
+++ b/src/web/EnrichedTextInput.tsx
@@ -378,13 +378,24 @@ export const EnrichedTextInput = ({
       },
       deleteAtSelection: () => {
         runFocused(editor, (c) => {
-          const { from, to } = editor.state.selection;
+          const { from, empty, $from } = editor.state.selection;
 
-          if (from !== to) {
+          // If have selection - we delete it
+          if (!empty) {
             return c.deleteSelection();
-          } else {
-            return c.deleteRange({ from: from - 1, to });
           }
+
+          const isAtBlockStart = $from.parentOffset === 0;
+
+          if (isAtBlockStart) {
+            // If caret is in the beginning of the line - we join two lines together
+            return c.joinBackward();
+          } else if (from > 1) {
+            // If caret is not in the beginning of the line - we delete previous character
+            return c.deleteRange({ from: from - 1, to: from });
+          }
+
+          return c.focus();
         });
       },
     }),


### PR DESCRIPTION
# Summary

Explain the **motivation** for making this change: here are some points to help you:

- This PR resolves https://github.com/software-mansion/react-native-enriched-html/issues/699
- This feature allows us to delete text programmatically by ref
- I implemented three new methods (for iOS, Android and web) that allows us to delete text (and other stuff) by ref
- It affects native iOS code, native Android code and web code

## Test Plan

To test this feature you can add manually new button that is going to call **deleteAtSelection** method and check it in different test case scenarios:

1. Delete character one by one
2. Delete selected text
3. Delete image
4. Any other deletion cases

## Screenshots / Videos

<img width="227" height="500" alt="output-ezgif com-resize" src="https://github.com/user-attachments/assets/d9f6167f-d544-41cc-b1ea-23f5e22a4977" />

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
| Web     |    ✅     |

