### PR TITLE
docs: known limitation with blurring the input

### DIFF
--- a/docs/docs/misc/known-limitations.md
+++ b/docs/docs/misc/known-limitations.md
@@ -32,3 +32,8 @@ We may add support for more tags and related functionality over time - see the
 not supported yet, the best way to let us know is to open a
 [GitHub issue](https://github.com/software-mansion/react-native-enriched-html/issues)
 in our repo.
+
+## Tapping outside the editor doesn't blur it
+
+On mobile, tapping outside of an `EnrichedTextInput` does not blur it. This is
+a limitation of React Native itself, not something specific to this library.

--- a/docs/docs/misc/known-limitations.md
+++ b/docs/docs/misc/known-limitations.md
@@ -33,7 +33,10 @@ not supported yet, the best way to let us know is to open a
 [GitHub issue](https://github.com/software-mansion/react-native-enriched-html/issues)
 in our repo.
 
-## Tapping outside the editor doesn't blur it
+## No global blur support on mobile
 
-On mobile, tapping outside of an `EnrichedTextInput` does not blur it. This is
-a limitation of React Native itself, not something specific to this library.
+On mobile, you can use `Keyboard.dismiss()` and `keyboardShouldPersistTaps` to blur
+the React Native's `TextInput` on taps outside of it. This doesn't work
+with `EnrichedTextInput`. This is a limitation of React Native itself, not
+something specific to this library: React Native doesn't expose
+`TextInputState` publicly, so we can't register our input in the React Native state.


### PR DESCRIPTION
# Summary

Tapping outside of `EnrichedTextInput` does not blur it on mobile. This is a RN limitation and was mentioned here #184 . Provided mention about that in the docs