### PR TITLE
fix(ios): stale head indent on selection change to a trailing newline

### DIFF
--- a/ios/enrichedInputTextView/EnrichedInputTextView.mm
+++ b/ios/enrichedInputTextView/EnrichedInputTextView.mm
@@ -56,6 +56,15 @@
     rect.origin.x = (containerWidth - rect.size.width) / 2.0;
   } else if (alignment == NSTextAlignmentRight) {
     rect.origin.x = containerWidth - rect.size.width;
+  } else {
+    // when we change selection to the last empty line in the editor,
+    // where we literally have no character there, UIKit seems to need to know
+    // the line's expected geometry (indent) and it derives typing attributes
+    // from the previous character (previous line). Happens even though we
+    // explicitly didn't want that in
+    // manageTypingAttributesWithOnlySelection:YES, so we can't trust typing
+    // attributes' pStyle here, manually setting the caret's position
+    rect.origin.x = 0;
   }
 
   return rect;


### PR DESCRIPTION
# Summary

When we had the editor's content ending with a newline, meant we had literally no character in that line at all. This caused UIKit to derive typing attributes from the previous character (previous line) on selection change. This happened even though we explicitly reset typing attributes in `manageTypingAttributesWithOnlySelection`, when `onlySelectionChanged` is true. 

E.g. we change selection to that empty newline, and typingAttributes get derived from an unordered list that is above it. This caused the list indent to be applied on an unstyled line, incorrectly moving the caret. This issue could be reproduced with any style that uses an indent - list styles, blockquote.

Fixed it by explicitly setting the caret's position on empty lines to `0`. Previously we were falling back to any values that were in the typing attributes state.

I've run all e2e tests, all passed.

## Test Plan

Reproduce the steps shown in the attached videos. Verify it's working  correctly.

## Screenshots / Videos

Before:

https://github.com/user-attachments/assets/20de93d1-7696-49a3-8e0b-0d4f282da35b

This also happened with other indent-modifying styles, e.g.

<img width="335" height="457" alt="image" src="https://github.com/user-attachments/assets/1f1b0147-0fd1-4a59-855e-be5f112bc1b7" />

<img width="332" height="455" alt="image" src="https://github.com/user-attachments/assets/ad4e6b1f-1801-489d-9d9d-f0e71014eb77" />


After:

https://github.com/user-attachments/assets/a3ce478e-fad9-4b3a-848e-a78587ab39a1

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
| Web     |    ❌     |

## Checklist

- [x] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
