### PR TITLE
fix(ios): don't clear typing attributes on empty editor focus

### DIFF
--- a/ios/inputAttributesManager/InputAttributesManager.mm
+++ b/ios/inputAttributesManager/InputAttributesManager.mm
@@ -152,6 +152,11 @@
   // Typing attributes get reset (except alignment) when only selection changed
   // to an empty line (or empty line with newline).
   if (onlySelectionChanged) {
+    // if there is no content, there is no need to clear the typing attributes
+    if (textView.textStorage.string.length == 0) {
+      return;
+    }
+
     NSRange paragraphRange =
         [textView.textStorage.string paragraphRangeForRange:selectedRange];
     // User changed selection to an empty line (or empty line with a newline).


### PR DESCRIPTION
# Summary

fixes #322 

Currently, in `manageTypingAttributesWithOnlySelection:YES`, we clear typing attributes and then apply the ones applicable to the content. We also do that when editor's content itself is empty, but when there is no content, there is no need to _reapply_ the typing attributes, as there is nothing to reapply on. That also introduced a case where a user would first set the active styles (typing attributes) programmatically, e.g. via a toolbar, and then focus it. This would result in priorly chosen styles to be reset, which is unintuitive and inconsistent to how it works on both Android and Web.

## Test Plan

Follow the steps in the attached video

## Screenshots / Videos

Before:

https://github.com/user-attachments/assets/a1b6139c-3eb7-4d68-9996-f305e3a03db6

After:

https://github.com/user-attachments/assets/e94db0b8-2824-4a2c-b40b-5375b8dd1abe

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |
| Web     |    ❌     |

## Checklist

- [ ] E2E tests are passing
- [ ] Required E2E tests have been added (if applicable)
