### PR TITLE
feat(web): pressable links in the input component

### DIFF
--- a/.playwright/tests/links.spec.ts
+++ b/.playwright/tests/links.spec.ts
@@ -33,6 +33,8 @@ const sel = {
     '[data-testid="test-links-apply-setlink-from-selection-button"]',
   selectionPayload: '[data-testid="test-links-selection-payload"]',
   onLinkDetectedPayload: '[data-testid="on-link-detected-payload"]',
+  onLinkPressEnabled: '[data-testid="test-links-onlinkpress-enabled"]',
+  onLinkPressPayload: '[data-testid="on-link-press-payload"]',
   editorInner: '[data-testid="test-links-editor"] .eti-editor',
   editorScreenshot: '[data-testid="test-links-editor"]',
   linkRegexMode: '[data-testid="test-links-link-regex-mode"]',
@@ -61,6 +63,10 @@ async function setTestLinksEditorHtml(page: Page, html: string): Promise<void> {
 
 async function getOnLinkDetectedPayload(page: Page): Promise<string> {
   return (await page.locator(sel.onLinkDetectedPayload).textContent()) ?? '';
+}
+
+async function getOnLinkPressPayload(page: Page): Promise<string> {
+  return (await page.locator(sel.onLinkPressPayload).textContent()) ?? '';
 }
 
 test('links display visual regression', async ({ page }) => {
@@ -415,6 +421,39 @@ test.describe('test-links onLinkDetected', () => {
         start: 0,
         end: 0,
       });
+  });
+});
+
+test.describe('test-links onLinkPress', () => {
+  test('clicking a link does nothing when onLinkPress is not provided', async ({
+    page,
+  }) => {
+    await gotoTestLinks(page);
+    await setTestLinksEditorHtml(
+      page,
+      '<html><p><a href="https://example.com">Example</a></p></html>'
+    );
+
+    await page.locator(sel.editorInner).locator('a').click();
+
+    await expect(page.locator(sel.onLinkPressPayload)).toHaveText('null');
+  });
+
+  test('clicking a link fires onLinkPress with the url when provided', async ({
+    page,
+  }) => {
+    await gotoTestLinks(page);
+    await page.check(sel.onLinkPressEnabled);
+    await setTestLinksEditorHtml(
+      page,
+      '<html><p><a href="https://example.com">Example</a></p></html>'
+    );
+
+    await page.locator(sel.editorInner).locator('a').click();
+
+    await expect
+      .poll(async () => getOnLinkPressPayload(page))
+      .toBe(JSON.stringify({ url: 'https://example.com' }));
   });
 });
 

--- a/apps/example-web/src/App.tsx
+++ b/apps/example-web/src/App.tsx
@@ -14,6 +14,7 @@ import {
   type OnSubmitEditing,
   type OnChangeMentionEvent,
   type OnMentionDetected,
+  type OnLinkPressEvent,
 } from 'react-native-enriched-html';
 import { WEB_DEFAULT_HTML_STYLE } from './defaultHtmlStyle';
 import type { NativeSyntheticEvent } from 'react-native';
@@ -224,6 +225,10 @@ function App() {
     setCurrentLink(e);
   };
 
+  const handleLinkPress = (e: OnLinkPressEvent) => {
+    console.log('[EnrichedTextInput] onLinkPress event', e);
+  };
+
   const handlePasteImages = (e: NativeSyntheticEvent<OnPasteImagesEvent>) => {
     const DEFAULT_W = 80;
     const DEFAULT_H = 80;
@@ -275,6 +280,7 @@ function App() {
           onChangeState={handleChangeState}
           onSubmitEditing={handleSubmitEditing}
           onLinkDetected={handleOnLinkDetected}
+          onLinkPress={handleLinkPress}
           onPasteImages={handlePasteImages}
           onStartMention={handleStartMention}
           onChangeMention={handleChangeMention}

--- a/apps/example-web/src/defaultHtmlStyle.ts
+++ b/apps/example-web/src/defaultHtmlStyle.ts
@@ -43,6 +43,7 @@ export const WEB_DEFAULT_HTML_STYLE: HtmlStyle = {
   a: {
     color: 'green',
     textDecorationLine: 'underline',
+    pressColor: 'darkblue',
   },
   ol: {
     gapWidth: 16,

--- a/apps/example-web/src/testScreens/TestLinks.tsx
+++ b/apps/example-web/src/testScreens/TestLinks.tsx
@@ -5,6 +5,7 @@ import {
   type EnrichedTextInputInstance,
   type OnChangeSelectionEvent,
   type OnLinkDetected,
+  type OnLinkPressEvent,
 } from 'react-native-enriched-html';
 import { WEB_DEFAULT_HTML_STYLE } from '../defaultHtmlStyle';
 
@@ -37,6 +38,9 @@ export function TestLinks() {
     useState<OnLinkDetected | null>(null);
   const [lastSelection, setLastSelection] =
     useState<OnChangeSelectionEvent | null>(null);
+  const [onLinkPressEnabled, setOnLinkPressEnabled] = useState(false);
+  const [lastOnLinkPress, setLastOnLinkPress] =
+    useState<OnLinkPressEvent | null>(null);
 
   useEffect(() => {
     setLinkRegexError('');
@@ -74,8 +78,29 @@ export function TestLinks() {
           onChangeSelection={(e) => {
             setLastSelection(e.nativeEvent);
           }}
+          onLinkPress={
+            onLinkPressEnabled
+              ? (e) => {
+                  setLastOnLinkPress(e);
+                }
+              : undefined
+          }
           linkRegex={appliedLinkRegex}
         />
+      </div>
+
+      <div>
+        <label>
+          onLinkPress enabled{' '}
+          <input
+            data-testid="test-links-onlinkpress-enabled"
+            type="checkbox"
+            checked={onLinkPressEnabled}
+            onChange={(e) => {
+              setOnLinkPressEnabled(e.target.checked);
+            }}
+          />
+        </label>
       </div>
 
       <div>
@@ -252,6 +277,10 @@ export function TestLinks() {
 
       <pre data-testid="on-link-detected-payload">
         {JSON.stringify(lastOnLinkDetected)}
+      </pre>
+
+      <pre data-testid="on-link-press-payload">
+        {JSON.stringify(lastOnLinkPress)}
       </pre>
 
       <pre data-testid="test-links-html-output">{editorHtml}</pre>

--- a/src/types.ts
+++ b/src/types.ts
@@ -222,6 +222,8 @@ export interface HtmlStyle {
   a?: {
     color?: ColorValue;
     textDecorationLine?: 'underline' | 'none';
+    /** @platform web */
+    pressColor?: ColorValue;
   };
   mention?: Record<string, MentionStyleProperties> | MentionStyleProperties;
   ol?: {
@@ -908,13 +910,7 @@ export interface EnrichedTextMentionStyleProperties extends MentionStyleProperti
   pressBackgroundColor?: ColorValue;
 }
 
-export interface EnrichedTextHtmlStyle extends Omit<
-  HtmlStyle,
-  'a' | 'mention'
-> {
-  a?: HtmlStyle['a'] & {
-    pressColor?: ColorValue;
-  };
+export interface EnrichedTextHtmlStyle extends Omit<HtmlStyle, 'mention'> {
   mention?:
     | Record<string, EnrichedTextMentionStyleProperties>
     | EnrichedTextMentionStyleProperties;

--- a/src/types.ts
+++ b/src/types.ts
@@ -723,6 +723,15 @@ export interface EnrichedTextInputProps extends Omit<ViewProps, 'children'> {
   /** Called when the editor auto-detects a URL matching `linkRegex`. */
   onLinkDetected?: (e: OnLinkDetected) => void;
 
+  /**
+   * Web only. Called when the user clicks a link inside the editor. If not
+   * provided, clicking a link has no effect (the default, cross-platform
+   * behavior).
+   *
+   * @platform web
+   */
+  onLinkPress?: (event: OnLinkPressEvent) => void;
+
   /** Called when the editor resolves a mention node. */
   onMentionDetected?: (e: OnMentionDetected) => void;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -910,7 +910,16 @@ export interface EnrichedTextMentionStyleProperties extends MentionStyleProperti
   pressBackgroundColor?: ColorValue;
 }
 
-export interface EnrichedTextHtmlStyle extends Omit<HtmlStyle, 'mention'> {
+export interface EnrichedTextHtmlStyle extends Omit<
+  HtmlStyle,
+  'a' | 'mention'
+> {
+  a?: Omit<NonNullable<HtmlStyle['a']>, 'pressColor'> & {
+    // the documentation comment below is to suppress the base HtmlStyle's
+    // web-only note about pressColor, as in EnrichedText it is cross-platform
+    /***/
+    pressColor?: ColorValue;
+  };
   mention?:
     | Record<string, EnrichedTextMentionStyleProperties>
     | EnrichedTextMentionStyleProperties;

--- a/src/utils/defaultHtmlStyle.ts
+++ b/src/utils/defaultHtmlStyle.ts
@@ -43,6 +43,7 @@ export const DEFAULT_HTML_STYLE: Required<HtmlStyle> = {
   a: {
     color: 'blue',
     textDecorationLine: 'underline',
+    pressColor: 'darkblue',
   },
   mention: {
     color: 'blue',
@@ -71,10 +72,6 @@ export const DEFAULT_HTML_STYLE: Required<HtmlStyle> = {
 
 export const DEFAULT_ENRICHED_TEXT_STYLE: Required<EnrichedTextHtmlStyle> = {
   ...DEFAULT_HTML_STYLE,
-  a: {
-    ...DEFAULT_HTML_STYLE.a,
-    pressColor: 'darkblue',
-  },
   mention: {
     ...DEFAULT_HTML_STYLE.mention,
     pressColor: 'darkblue',

--- a/src/web/EnrichedText.css
+++ b/src/web/EnrichedText.css
@@ -129,7 +129,16 @@
   transition: none;
 }
 
-.et-view a:active {
+.et-view a {
+  cursor: default
+}
+
+.et-link-pressable a {
+  cursor: pointer;
+}
+
+.et-link-pressable a:active,
+.et-link-pressable a.et-link-pressed {
   color: var(--et-link-press-color);
 }
 

--- a/src/web/EnrichedText.tsx
+++ b/src/web/EnrichedText.tsx
@@ -11,7 +11,10 @@ import './EnrichedText.css';
 import { enrichedTextStyleToCSSProperties } from './styleConversion/enrichedTextStyleToCSSProperties';
 import { mergeWithDefaultEnrichedTextHtmlStyle } from './styleConversion/htmlStyleToCSSVariables';
 import { enrichedTextHtmlStyleToCSSVariables } from './styleConversion/htmlStyleToCSSVariables';
-import { ENRICHED_TEXT_CLASSNAME } from './constants/classNames';
+import {
+  ENRICHED_TEXT_CLASSNAME,
+  LINK_PRESSABLE_CLASSNAME,
+} from './constants/classNames';
 import { enrichedTextThemingToCSSProperties } from './styleConversion/enrichedThemingToCSSProperties';
 import { buildMentionRulesCSS } from './styleConversion/buildMentionRulesCSS';
 import { sanitizeHtml } from './sanitization/htmlSanitizer';
@@ -136,7 +139,11 @@ export const EnrichedText = memo(
           ref={containerRef}
           tabIndex={-1}
           style={finalStyle}
-          className={ENRICHED_TEXT_CLASSNAME}
+          className={
+            onLinkPress
+              ? `${ENRICHED_TEXT_CLASSNAME} ${LINK_PRESSABLE_CLASSNAME}`
+              : ENRICHED_TEXT_CLASSNAME
+          }
           onFocus={(event) =>
             onFocus?.(adaptWebToNativeEvent(event, { target: -1 }))
           }

--- a/src/web/EnrichedTextInput.tsx
+++ b/src/web/EnrichedTextInput.tsx
@@ -117,6 +117,7 @@ export const EnrichedTextInput = ({
   onChangeHtml,
   onChangeState,
   onLinkDetected,
+  onLinkPress,
   onSubmitEditing,
   returnKeyType,
   submitBehavior,
@@ -162,6 +163,7 @@ export const EnrichedTextInput = ({
   const submitBehaviorRef = useStableRef(submitBehavior);
   const onSubmitEditingRef = useStableRef(onSubmitEditing);
   const onKeyPressRef = useStableRef(onKeyPress);
+  const onLinkPressRef = useStableRef(onLinkPress);
   const useHtmlNormalizerRef = useStableRef(useHtmlNormalizer);
   const sanitizationConfigRef = useStableRef(sanitizationConfig);
   const mentionCallbacksRef = useStableRef(mentionCallbacks);
@@ -187,6 +189,18 @@ export const EnrichedTextInput = ({
     }
 
     return false;
+  };
+
+  const handleLinkPress = (event: PointerEvent): boolean => {
+    const onPress = onLinkPressRef.current;
+    if (!onPress) return false;
+    const anchor = (event.target as HTMLElement).closest?.('a');
+    if (!anchor) return false;
+    const url = anchor.getAttribute('href');
+    if (!url) return false;
+    event.preventDefault();
+    onPress({ url });
+    return true;
   };
 
   const linkEmitterRef = useRef<LinkEmitterState>({
@@ -281,6 +295,9 @@ export const EnrichedTextInput = ({
       },
       editorProps: {
         handleKeyDown: (view, event) => handleKeyDown(view.state.doc, event),
+        handleDOMEvents: {
+          click: (_view, event) => handleLinkPress(event),
+        },
         handlePaste: (_view, event) =>
           handleClipboardPasteImages(
             event,

--- a/src/web/EnrichedTextInput.tsx
+++ b/src/web/EnrichedTextInput.tsx
@@ -79,7 +79,10 @@ import { StripMarksOnImagePlugin } from './pmPlugins/StripMarksOnImagePlugin';
 import { ShortcutPlugin } from './pmPlugins/ShortcutPlugin';
 import { TextShortcutsPlugin } from './pmPlugins/TextShortcutsPlugin';
 import { returnKeyTypeToEnterKeyHint } from './nativeMappers/returnKeyTypeToEnterKeyHint';
-import { ENRICHED_TEXT_INPUT_CLASSNAME } from './constants/classNames';
+import {
+  ENRICHED_TEXT_INPUT_CLASSNAME,
+  LINK_PRESSABLE_CLASSNAME,
+} from './constants/classNames';
 import { AutolinkPlugin } from './pmPlugins/AutolinkPlugin';
 import { useStableRef } from './utils/useStableRef';
 import {
@@ -88,6 +91,7 @@ import {
 } from './sanitization/htmlSanitizer';
 import { assertBrowserEnvironment } from './utils/assertBrowserEnvironment';
 import { runSafelyInEditor } from './utils/runSafelyInEditor';
+import { useLinkPress } from './htmlExtensions/useLinkPress';
 
 function runFocused(
   editor: Editor,
@@ -191,17 +195,9 @@ export const EnrichedTextInput = ({
     return false;
   };
 
-  const handleLinkPress = (event: PointerEvent): boolean => {
-    const onPress = onLinkPressRef.current;
-    if (!onPress) return false;
-    const anchor = (event.target as HTMLElement).closest?.('a');
-    if (!anchor) return false;
-    const url = anchor.getAttribute('href');
-    if (!url) return false;
-    event.preventDefault();
-    onPress({ url });
-    return true;
-  };
+  const { handleLinkPress, handleLinkMouseDown } = useLinkPress(
+    () => onLinkPressRef.current
+  );
 
   const linkEmitterRef = useRef<LinkEmitterState>({
     linkRegex,
@@ -297,6 +293,7 @@ export const EnrichedTextInput = ({
         handleKeyDown: (view, event) => handleKeyDown(view.state.doc, event),
         handleDOMEvents: {
           click: (_view, event) => handleLinkPress(event),
+          mousedown: (_view, event) => handleLinkMouseDown(event),
         },
         handlePaste: (_view, event) =>
           handleClipboardPasteImages(
@@ -475,7 +472,11 @@ export const EnrichedTextInput = ({
       {mentionRulesCSS ? <style>{mentionRulesCSS}</style> : null}
       <EditorContent
         editor={editor}
-        className={ENRICHED_TEXT_INPUT_CLASSNAME}
+        className={
+          onLinkPress
+            ? `${ENRICHED_TEXT_INPUT_CLASSNAME} ${LINK_PRESSABLE_CLASSNAME}`
+            : ENRICHED_TEXT_INPUT_CLASSNAME
+        }
         style={finalStyle}
         data-placeholder={placeholder}
       />

--- a/src/web/constants/classNames.ts
+++ b/src/web/constants/classNames.ts
@@ -1,2 +1,4 @@
 export const ENRICHED_TEXT_INPUT_CLASSNAME = 'eti-editor';
 export const ENRICHED_TEXT_CLASSNAME = 'et-view';
+export const LINK_PRESSABLE_CLASSNAME = 'et-link-pressable';
+export const LINK_PRESSED_CLASSNAME = 'et-link-pressed';

--- a/src/web/htmlExtensions/useLinkPress.ts
+++ b/src/web/htmlExtensions/useLinkPress.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from 'react';
+import type { EnrichedTextInputProps } from '../..';
+import { LINK_PRESSED_CLASSNAME } from '../constants/classNames';
+
+export function useLinkPress(
+  getOnLinkPress: () => EnrichedTextInputProps['onLinkPress']
+) {
+  const pressedLinkRef = useRef<HTMLElement | null>(null);
+
+  const handleLinkPress = (event: PointerEvent): boolean => {
+    if (!getOnLinkPress()) return false;
+    const onPress = getOnLinkPress();
+    if (!onPress) return false;
+    const anchor = (event.target as HTMLElement).closest?.('a');
+    if (!anchor) return false;
+    const url = anchor.getAttribute('href');
+    if (!url) return false;
+    event.preventDefault();
+    onPress({ url });
+    return true;
+  };
+
+  const handleLinkMouseDown = (event: MouseEvent): boolean => {
+    if (!getOnLinkPress()) return false;
+    const anchor = (event.target as HTMLElement).closest?.('a');
+    if (!anchor) return false;
+    anchor.classList.add(LINK_PRESSED_CLASSNAME);
+    pressedLinkRef.current = anchor;
+    return false;
+  };
+
+  useEffect(() => {
+    const clearPressedLink = () => {
+      pressedLinkRef.current?.classList.remove(LINK_PRESSED_CLASSNAME);
+      pressedLinkRef.current = null;
+    };
+    document.addEventListener('mouseup', clearPressedLink);
+    return () => document.removeEventListener('mouseup', clearPressedLink);
+  }, []);
+
+  return { handleLinkPress, handleLinkMouseDown };
+}

--- a/src/web/htmlExtensions/useLinkPress.ts
+++ b/src/web/htmlExtensions/useLinkPress.ts
@@ -8,7 +8,6 @@ export function useLinkPress(
   const pressedLinkRef = useRef<HTMLElement | null>(null);
 
   const handleLinkPress = (event: PointerEvent): boolean => {
-    if (!getOnLinkPress()) return false;
     const onPress = getOnLinkPress();
     if (!onPress) return false;
     const anchor = (event.target as HTMLElement).closest?.('a');

--- a/src/web/styleConversion/__tests__/htmlStyleToCSSVariables.test.ts
+++ b/src/web/styleConversion/__tests__/htmlStyleToCSSVariables.test.ts
@@ -16,7 +16,6 @@ const defaultMentionOnlyResolved = {
   default: { ...DEFAULT_HTML_STYLE.mention },
 };
 
-const DEFAULT_LINK_PRESS_COLOR = DEFAULT_ENRICHED_TEXT_STYLE.a.pressColor;
 const DEFAULT_MENTION_PRESS = DEFAULT_ENRICHED_TEXT_STYLE.mention as {
   pressColor?: string;
   pressBackgroundColor?: string;
@@ -205,11 +204,16 @@ describe('htmlStyleToCSSVariables', () => {
   it('maps anchor link styles to CSS variables', () => {
     expect(
       htmlStyleToCSSVariables({
-        a: { color: 'blue', textDecorationLine: 'underline' },
+        a: {
+          color: 'blue',
+          textDecorationLine: 'underline',
+          pressColor: 'red',
+        },
       })
     ).toMatchObject({
       '--et-link-color': 'blue',
       '--et-link-text-decoration-line': 'underline',
+      '--et-link-press-color': 'red',
     });
   });
 
@@ -350,7 +354,6 @@ describe('enrichedTextHtmlStyleToCSSVariables', () => {
       a: { color: 'blue' },
       mention: { color: '#f00' },
     }) as Record<string, string>;
-    expect(vars['--et-link-press-color']).toBe(DEFAULT_LINK_PRESS_COLOR);
     expect(vars['--et-mention-default-press-color']).toBe(
       DEFAULT_MENTION_PRESS_COLOR
     );
@@ -364,7 +367,6 @@ describe('enrichedTextHtmlStyleToCSSVariables', () => {
       string,
       string
     >;
-    expect(vars['--et-link-press-color']).toBe(DEFAULT_LINK_PRESS_COLOR);
     expect(vars['--et-mention-default-press-color']).toBe(
       DEFAULT_MENTION_PRESS_COLOR
     );

--- a/src/web/styleConversion/htmlStyleToCSSVariables.ts
+++ b/src/web/styleConversion/htmlStyleToCSSVariables.ts
@@ -60,11 +60,6 @@ export function mergeWithDefaultEnrichedTextHtmlStyle(
     DEFAULT_ENRICHED_TEXT_STYLE
   );
 
-  const a = {
-    ...DEFAULT_ENRICHED_TEXT_STYLE.a,
-    ...style?.a,
-  };
-
   const mentionDefaults = DEFAULT_ENRICHED_TEXT_STYLE.mention;
   const passedMentionMap = htmlStyle?.mention;
   const mergedMentionMap = merged.mention as Record<
@@ -84,7 +79,6 @@ export function mergeWithDefaultEnrichedTextHtmlStyle(
 
   return {
     ...merged,
-    a,
     mention,
   } as Required<EnrichedTextHtmlStyle>;
 }
@@ -101,6 +95,7 @@ const ET_CSS_VARS = {
   codeblockBorderRadius: '--et-codeblock-border-radius',
   linkColor: '--et-link-color',
   linkTextDecorationLine: '--et-link-text-decoration-line',
+  linkPressColor: '--et-link-press-color',
   ulBulletColor: '--et-ul-bullet-color',
   ulBulletSize: '--et-ul-bullet-size',
   ulMarginLeft: '--et-ul-margin-left',
@@ -189,6 +184,7 @@ function applyLinkVars(
   if (anchor?.textDecorationLine != null) {
     vars[ET_CSS_VARS.linkTextDecorationLine] = anchor.textDecorationLine;
   }
+  setColorVar(vars, ET_CSS_VARS.linkPressColor, anchor?.pressColor);
 }
 
 function applyUnorderedListVars(
@@ -278,8 +274,6 @@ export function htmlStyleToCSSVariables(htmlStyle: HtmlStyle): CSSProperties {
   return vars as CSSProperties;
 }
 
-const ET_LINK_PRESS_COLOR_VAR = '--et-link-press-color';
-
 export const ET_MENTION_PRESS_CSS_VARS = {
   pressColor: (indicator: string) =>
     `--et-mention-${indicatorToMentionCssKey(indicator)}-press-color`,
@@ -289,17 +283,6 @@ export const ET_MENTION_PRESS_CSS_VARS = {
 
 const DEFAULT_MENTION_PRESS =
   DEFAULT_ENRICHED_TEXT_STYLE.mention as EnrichedTextMentionStyleProperties;
-
-function expandVarsWithEnrichedTextLink(
-  vars: Record<string, string>,
-  anchor?: EnrichedTextHtmlStyle['a']
-): void {
-  setColorVar(
-    vars,
-    ET_LINK_PRESS_COLOR_VAR,
-    anchor?.pressColor ?? DEFAULT_ENRICHED_TEXT_STYLE.a.pressColor
-  );
-}
 
 function expandVarsWithEnrichedTextMention(
   vars: Record<string, string>,
@@ -337,7 +320,6 @@ function expandCSSPropertiesWithEnrichedTextHtmlStyle(
   cssProperties: CSSProperties
 ): CSSProperties {
   const vars = { ...cssProperties } as Record<string, string>;
-  expandVarsWithEnrichedTextLink(vars, htmlStyle?.a);
   expandVarsWithEnrichedTextMention(vars, htmlStyle?.mention);
   return vars as CSSProperties;
 }


### PR DESCRIPTION
# Summary

Closes #790 

- implemented `onLinkPress` prop for the `EnrichedTextInput` component on Web. If not provided, the behavior doesn't change.
- as now both components use `a.pressColor` in `htmlStyle`, code regarding the previously `EnrichedText`-only `a.pressColor` has been refactored.
- also I've noticed that in `EnrichedText` when `onLinkPress` was not provided, you could still 'click' the link - `pressColor` was applied and cursor was changed to `pointer`. Fixed.

All e2e and jest web tests pass.

## Test Plan

The onPressLink event is wired up in the example app, you can see its effect in the console logs.

Play around with it, see if the the link's colors are correctly changing when pressing. Then you can remove the `onLinkPress` prop from both the `EnrichedTextInput` and `EnrichedText` component and see that the links will not react on clicks anymore.

## Screenshots / Videos

With `onLinkPress` defined:

https://github.com/user-attachments/assets/0a3a9e32-701b-474f-86dc-2b855e662850

With `onLinkPress` not defined:

https://github.com/user-attachments/assets/834efa57-060d-4f16-b918-454982fc8d85

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ❌     |
| Web     |    ✅     |

## Checklist

- [x] E2E tests are passing
- [x] Required E2E tests have been added (if applicable)
